### PR TITLE
allow constant interpolations of primitives for scala 3

### DIFF
--- a/tests/shared/src/test/scala/org/typelevel/literally/LiterallySuite.scala
+++ b/tests/shared/src/test/scala/org/typelevel/literally/LiterallySuite.scala
@@ -40,4 +40,27 @@ class LiterallySuite extends FunSuite {
     assert(compileErrors("""port"-1"""").nonEmpty)
     assert(compileErrors("""port"100000"""").nonEmpty)
   }
+
+  final val intOne = 1
+  final val stringTwo = "2"
+  final val doubleThree = 3.0
+  final val charFour = '4'
+
+  test("literal allows interpolation of primitive constants") {
+    assertEquals(port"1$stringTwo", Port.fromInt(12).get)
+    assertEquals(port"$intOne", Port.fromInt(1).get)
+    assertEquals(short"$doubleThree", ShortString.fromString("3.0").get)
+    assertEquals(port"1${stringTwo}3$charFour", Port.fromInt(1234).get)
+    assertEquals(port"${1}${"2"}${'3'}", Port.fromInt(123).get)
+  }
+
+  final val onetwo = (1, 2)
+  test("literal disallows interpolation of non-primivive constants") {
+    assert(clue(compileErrors("""port"$onetwo"""")).contains("interpolated literal values must be primitive types"))
+  }
+
+  test("literal disallows interpolation of non-constant values") {
+    assert(clue(compileErrors("""val aString = "1"; port"$aString"""")).contains("interpolated values need to be compile-time constants"))
+  }
+
 }


### PR DESCRIPTION
an implementation for https://github.com/typelevel/literally/issues/44 for scala 3.

https://github.com/typelevel/literally/issues/44

This doesn't allow for "composed" values like lists, tuples, and other things you create a FromExpr for -- it just does dumb enumeration of types, as I couldn't manage to find a solution that does arbitrary FromExpr's. The cop out argument is that you're not going to need those anyway -- interpolating literal `('f', "bar", 2)` into a string just not something that tends to happen. This of course is a cop out, if I could have gotten it to work, I would have suggested that.